### PR TITLE
Allow Item Frame data

### DIFF
--- a/src/main/java/de/cubeside/itemcontrol/checks/CheckEntityData.java
+++ b/src/main/java/de/cubeside/itemcontrol/checks/CheckEntityData.java
@@ -1,5 +1,6 @@
 package de.cubeside.itemcontrol.checks;
 
+import de.cubeside.itemcontrol.ItemChecker;
 import de.cubeside.itemcontrol.config.GroupConfig;
 import de.cubeside.itemcontrol.util.ConfigUtil;
 import de.cubeside.nmsutils.nbt.CompoundTag;
@@ -76,6 +77,15 @@ public class CheckEntityData implements ComponentCheck {
                     itemComponentsTag.remove(key);
                     changed = true;
                 } else {
+                    CompoundTag itemStack = entityData.getCompound("Item");
+                    if (itemStack != null) {
+                        Boolean result = ItemChecker.filterItem(itemStack, group);
+                        changed |= result != null && result;
+                        if (result == null) {
+                            entityData.remove("Item");
+                            changed = true;
+                        }
+                    }
                     for (String s : entityData.getAllKeys()) {
                         if (allowItemsInItemFrames) {
                             if (!allowedKeys.contains(s) && !s.equals("Item")) {

--- a/src/main/java/de/cubeside/itemcontrol/checks/CheckEntityData.java
+++ b/src/main/java/de/cubeside/itemcontrol/checks/CheckEntityData.java
@@ -24,6 +24,9 @@ public class CheckEntityData implements ComponentCheck {
 
     private boolean allowItemsInItemFrames;
 
+
+    private static final Set<String> allowedKeys = new HashSet<>(Arrays.asList("id", "ItemDropChance", "ItemRotation", "Invisible", "Fixed", "Silent", "Invulnerable", "Glowing", "Tags"));
+
     @Override
     public NamespacedKey getComponentKey() {
         return KEY;
@@ -34,7 +37,7 @@ public class CheckEntityData implements ComponentCheck {
         ConfigurationSection data = ConfigUtil.getOrCreateSection(section, KEY.asMinimalString());
         allow = ConfigUtil.getOrCreate(data, "allow", false);
         allowPaintings = ConfigUtil.getOrCreate(data, "allowPaintings", true);
-        allowItemFrames = ConfigUtil.getOrCreate(data, "allowItemFrames", true);
+        allowItemFrames = ConfigUtil.getOrCreate(data, "allowItemFrames", false);
         allowItemsInItemFrames = ConfigUtil.getOrCreate(data, "allowItemsInItemFrames", false);
     }
 
@@ -74,7 +77,6 @@ public class CheckEntityData implements ComponentCheck {
                     changed = true;
                 } else {
                     for (String s : entityData.getAllKeys()) {
-                        Set<String> allowedKeys = new HashSet<>(Arrays.asList("id", "ItemDropChance", "ItemRotation", "Invisible", "Fixed", "Silent", "Invulnerable", "Glowing", "UUID", "Tags"));
                         if (allowItemsInItemFrames) {
                             if (!allowedKeys.contains(s) && !s.equals("Item")) {
                                 entityData.remove(s);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -83,6 +83,8 @@ groups:
       entity_data:
         allow: false
         allowPaintings: true
+        allowItemFrames: true
+        allowItemsInItemFrames: false
       equippable:
         allow: false
       firework_explosion:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -83,7 +83,7 @@ groups:
       entity_data:
         allow: false
         allowPaintings: true
-        allowItemFrames: true
+        allowItemFrames: false
         allowItemsInItemFrames: false
       equippable:
         allow: false


### PR DESCRIPTION
This PR adds an option under `entity_data` to allow Item Frame data, as well as a sub-option to allow Items inside Item Frames.

This was created because Invisible Item Frames (which are quite useful in Creative building) require the `entity_data` tag to function but allowing all `entity_data` just so Invisible Item Frames work is obviously not ideal. 

While working on it, I chose to allow all Item Frame specific entity data, such as `Fixed`, `Glowing`, etc., as they can all be useful when building, and are not harmful or overly exploitable (to my knowledge).

I've tested this quite extensively, and believe it is implemented properly; If there are any changes that need to be made, please let me know.