### PR TITLE
Add an option to allow Armor Stands + Items in Armor Stands, under Entity Data

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -85,6 +85,8 @@ groups:
         allowPaintings: true
         allowItemFrames: false
         allowItemsInItemFrames: false
+        allowArmorStands: false
+        allowItemsInArmorStands: false
       equippable:
         allow: false
       firework_explosion:


### PR DESCRIPTION
As the title says, this PR adds an option to allow Armor Stands, and Items inside of Armor Stands, under the Entity Data section.

Similar (identical, really) to #12, it filters the items inside of the armor stand properly, as well as all the components inside of the armor stands entity_data.

The array of allowed keys for armor stands includes the vast majority of relevant components, with only a few commonly exploited ones like `Passengers` left out.

I've also included `ArmorItems` and `HandItems` to allow for compatibility back through at least 1.21.4 (in 1.21.5+ it uses `equipment` instead).

The only potential exploit that this would allow (that I'm aware of) are armor stands with laggy names (or other Text/Name-based exploits). If you would like, I can add a comment above the config options warning users of that potential danger.

In the future I would like to rewrite the CheckEntityData class to allow for more fine-grained control over some or all of the components inside of entity_data (notably CustomName and CustomNameVisible), but for now I think this will do.